### PR TITLE
Deep links before onboarding

### DIFF
--- a/certificatesUITests/DeepLinkOnFreshInstall.swift
+++ b/certificatesUITests/DeepLinkOnFreshInstall.swift
@@ -68,4 +68,53 @@ class DeepLinkOnFreshInstall: XCTestCase {
         XCTAssert(app.collectionViews.cells["Greendale College"].waitForExistence(timeout: 5))
     }
     
+    func testAddCertificateLinkWithExistingAccount() {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        let app = XCUIApplication()
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        
+        // Launch Safari, go to our test page, and click our universal link.
+        safari.launch()
+        safari.otherElements["URL"].tap()
+        safari.textFields["URL"].typeText("http://localhost:1234/links/universal-links\n")
+        let webpage = safari.staticTexts["Add Issuer Links"]
+        XCTAssert(webpage.waitForExistence(timeout: 5))
+        safari.links["Add Accepting Certificate"].tap()
+        
+        XCTAssert(app.buttons["I ALREADY HAVE ONE"].waitForExistence(timeout: 5))
+        app.buttons["I ALREADY HAVE ONE"].tap()
+        
+        let scrollViewsQuery = app.scrollViews
+        let textView = scrollViewsQuery.otherElements.containing(.image, identifier:"Logo").children(matching: .other).element.children(matching: .textView).element
+        textView.tap()
+        textView.typeText(testPassphrase)
+        app.buttons["Done"].tap()
+        
+        // At this point, it should auto-add the issuer. Let's just wait until it shows up
+        XCTAssert(app.collectionViews.cells["Greendale College"].waitForExistence(timeout: 5))
+    }
+    
+    func testAddCertificateLinkWithNewAccount() {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        let app = XCUIApplication()
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        
+        // Launch Safari, go to our test page, and click our universal link.
+        safari.launch()
+        safari.otherElements["URL"].tap()
+        safari.textFields["URL"].typeText("http://localhost:1234/links/universal-links\n")
+        let webpage = safari.staticTexts["Add Issuer Links"]
+        XCTAssert(webpage.waitForExistence(timeout: 5))
+        safari.links["Add Accepting Certificate"].tap()
+        
+        XCTAssert(app.buttons["NEW ACCOUNT"].waitForExistence(timeout: 5))
+        app.buttons["NEW ACCOUNT"].tap()
+        app.buttons["GENERATE PASSPHRASE"].tap()
+        app.buttons["DONE"].tap()
+        
+        // At this point, it should auto-add the issuer. Let's just wait until it shows up
+        XCTAssert(app.collectionViews.cells["Greendale College"].waitForExistence(timeout: 5))
+    }
 }

--- a/certificatesUITests/DeepLinkOnFreshInstall.swift
+++ b/certificatesUITests/DeepLinkOnFreshInstall.swift
@@ -18,7 +18,34 @@ class DeepLinkOnFreshInstall: XCTestCase {
         app.launch()
     }
     
-    func testAddIssuerLink() {
+    func testAddIssuerLinkWithExistingAccount() {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        let app = XCUIApplication()
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        
+        // Launch Safari, go to our test page, and click our universal link.
+        safari.launch()
+        safari.otherElements["URL"].tap()
+        safari.textFields["URL"].typeText("http://localhost:1234/links/universal-links\n")
+        let webpage = safari.staticTexts["Add Issuer Links"]
+        XCTAssert(webpage.waitForExistence(timeout: 5))
+        safari.links["Add Accepting Issuer"].tap()
+        
+        XCTAssert(app.buttons["I ALREADY HAVE ONE"].waitForExistence(timeout: 5))
+        app.buttons["I ALREADY HAVE ONE"].tap()
+        
+        let scrollViewsQuery = app.scrollViews
+        let textView = scrollViewsQuery.otherElements.containing(.image, identifier:"Logo").children(matching: .other).element.children(matching: .textView).element
+        textView.tap()
+        textView.typeText(testPassphrase)
+        app.buttons["Done"].tap()
+        
+        // At this point, it should auto-add the issuer. Let's just wait until it shows up
+        XCTAssert(app.collectionViews.cells["Greendale College"].waitForExistence(timeout: 5))
+    }
+    
+    func testAddIssuerLinkWithNewAccount() {
         // Use recording to get started writing UI tests.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
         let app = XCUIApplication()
@@ -33,6 +60,12 @@ class DeepLinkOnFreshInstall: XCTestCase {
         safari.links["Add Accepting Issuer"].tap()
         
         XCTAssert(app.buttons["NEW ACCOUNT"].waitForExistence(timeout: 5))
+        app.buttons["NEW ACCOUNT"].tap()
+        app.buttons["GENERATE PASSPHRASE"].tap()
+        app.buttons["DONE"].tap()
+        
+        // At this point, it should auto-add the issuer. Let's just wait until it shows up
+        XCTAssert(app.collectionViews.cells["Greendale College"].waitForExistence(timeout: 5))
     }
     
 }

--- a/certificatesUITests/DeepLinkOnFreshInstall.swift
+++ b/certificatesUITests/DeepLinkOnFreshInstall.swift
@@ -1,0 +1,38 @@
+//
+//  DeepLinkOnFreshInstall.swift
+//  certificatesUITests
+//
+//  Created by Chris Downie on 9/29/17.
+//  Copyright © 2017 Learning Machine, Inc. All rights reserved.
+//
+
+import XCTest
+
+class DeepLinkOnFreshInstall: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        
+        let app = XCUIApplication()
+        app.launchArguments = [ "--reset-data" ]
+        app.launch()
+    }
+    
+    func testAddIssuerLink() {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        let app = XCUIApplication()
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        
+        // Launch Safari, go to our test page, and click our universal link.
+        safari.launch()
+        safari.otherElements["URL"].tap()
+        safari.textFields["URL"].typeText("http://localhost:1234/links/universal-links\n")
+        let webpage = safari.staticTexts["Add Issuer Links"]
+        XCTAssert(webpage.waitForExistence(timeout: 5))
+        safari.links["Add Accepting Issuer"].tap()
+        
+        XCTAssert(app.buttons["NEW ACCOUNT"].waitForExistence(timeout: 5))
+    }
+    
+}

--- a/certificatesUITests/DeepLinkOnFreshInstall.swift
+++ b/certificatesUITests/DeepLinkOnFreshInstall.swift
@@ -18,6 +18,7 @@ class DeepLinkOnFreshInstall: XCTestCase {
         app.launch()
     }
     
+    // MARK: - Accepting issuer with add issuer & add certificate links
     func testAddIssuerLinkWithExistingAccount() {
         // Use recording to get started writing UI tests.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
@@ -91,8 +92,8 @@ class DeepLinkOnFreshInstall: XCTestCase {
         textView.typeText(testPassphrase)
         app.buttons["Done"].tap()
         
-        // At this point, it should auto-add the issuer. Let's just wait until it shows up
-        XCTAssert(app.collectionViews.cells["Greendale College"].waitForExistence(timeout: 5))
+        // At this point, it should auto-add the certificate. Let's just wait until it shows up.
+        XCTAssert(app.navigationBars["You're a student"].waitForExistence(timeout: 5))
     }
     
     func testAddCertificateLinkWithNewAccount() {
@@ -114,7 +115,8 @@ class DeepLinkOnFreshInstall: XCTestCase {
         app.buttons["GENERATE PASSPHRASE"].tap()
         app.buttons["DONE"].tap()
         
-        // At this point, it should auto-add the issuer. Let's just wait until it shows up
-        XCTAssert(app.collectionViews.cells["Greendale College"].waitForExistence(timeout: 5))
+        // At this point, it should auto-add the certificate. Let's just wait until it shows up.
+        XCTAssert(app.navigationBars["You're a student"].waitForExistence(timeout: 5))
     }
+    
 }

--- a/certificatesUITests/DeepLinkOnFreshInstall.swift
+++ b/certificatesUITests/DeepLinkOnFreshInstall.swift
@@ -119,4 +119,55 @@ class DeepLinkOnFreshInstall: XCTestCase {
         XCTAssert(app.navigationBars["You're a student"].waitForExistence(timeout: 5))
     }
     
+    // MARK: - Alternate issuer responses
+    func testAddRejectingIssuerLinkWithNewAccount() {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        let app = XCUIApplication()
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        
+        // Launch Safari, go to our test page, and click our universal link.
+        safari.launch()
+        safari.otherElements["URL"].tap()
+        safari.textFields["URL"].typeText("http://localhost:1234/links/universal-links\n")
+        let webpage = safari.staticTexts["Add Issuer Links"]
+        XCTAssert(webpage.waitForExistence(timeout: 5))
+        safari.links["Add Rejecting Issuer"].tap()
+        
+        XCTAssert(app.buttons["NEW ACCOUNT"].waitForExistence(timeout: 5))
+        app.buttons["NEW ACCOUNT"].tap()
+        app.buttons["GENERATE PASSPHRASE"].tap()
+        app.buttons["DONE"].tap()
+        
+        XCTAssert(app.alerts["Add Issuer Failed"].waitForExistence(timeout: 5))
+    }
+    
+    func testAddWebAuthIssuerLinkWithNewAccount() {
+        // Use recording to get started writing UI tests.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        let app = XCUIApplication()
+        let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
+        
+        // Launch Safari, go to our test page, and click our universal link.
+        safari.launch()
+        safari.otherElements["URL"].tap()
+        safari.textFields["URL"].typeText("http://localhost:1234/links/universal-links\n")
+        let webpage = safari.staticTexts["Add Issuer Links"]
+        XCTAssert(webpage.waitForExistence(timeout: 5))
+        safari.links["Add WebAuth Issuer"].tap()
+        
+        XCTAssert(app.buttons["NEW ACCOUNT"].waitForExistence(timeout: 5))
+        app.buttons["NEW ACCOUNT"].tap()
+        app.buttons["GENERATE PASSPHRASE"].tap()
+        app.buttons["DONE"].tap()
+        
+
+        XCTAssert(app.navigationBars["Log In To Issuer"].waitForExistence(timeout: 5))
+        XCTAssert(app.staticTexts["Web Authentication Challenge"].waitForExistence(timeout: 5))
+        app.links["Yes"].tap()
+        
+        XCTAssert(app.navigationBars["Issuers"].waitForExistence(timeout: 5))
+        XCTAssertEqual(app.collectionViews.cells.count, 1)
+        XCTAssert(app.collectionViews.cells["Web Auth Issuer"].exists)
+    }
 }

--- a/certificatesUITests/wiremock/__files/links/universal-links.html
+++ b/certificatesUITests/wiremock/__files/links/universal-links.html
@@ -14,6 +14,11 @@
     <li><a href="https://wallet.blockcerts.org/#/introduce-recipient/http:%2F%2Flocalhost:1234%2Fissuer%2Frejecting/12345">Add Rejecting Issuer</a></li>
     <li><a href="https://wallet.blockcerts.org/#/introduce-recipient/http:%2F%2Flocalhost:1234%2Fissuer%2Fweb-auth/12345">Add WebAuth Issuer</a></li>
   </ul>
+
+  <h1>Add Certificate Links</h1>
+  <ul>
+    <li><a href="https://wallet.blockcerts.org/#/import-certificate/http:%2F%2Flocalhost:1234%2Fissuer%2Faccepting%2Fcertificates%2Fstudent.json">Add Accepting Certificate</a></li>
+  </ul>
 </body>
 
 </html>

--- a/certificatesUITests/wiremock/__files/links/universal-links.html
+++ b/certificatesUITests/wiremock/__files/links/universal-links.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Be Honest</title>
+</head>
+
+<body>
+  <h1>Add Issuer Links</h1>
+  <ul>
+    <li><a href="https://wallet.blockcerts.org/#/introduce-recipient/http:%2F%2Flocalhost:1234%2Fissuer%2Faccepting/12345">Add Accepting Issuer</a></li>
+    <li><a href="https://wallet.blockcerts.org/#/introduce-recipient/http:%2F%2Flocalhost:1234%2Fissuer%2Frejecting/12345">Add Rejecting Issuer</a></li>
+    <li><a href="https://wallet.blockcerts.org/#/introduce-recipient/http:%2F%2Flocalhost:1234%2Fissuer%2Fweb-auth/12345">Add WebAuth Issuer</a></li>
+  </ul>
+</body>
+
+</html>

--- a/certificatesUITests/wiremock/mappings/links/universal-links.json
+++ b/certificatesUITests/wiremock/mappings/links/universal-links.json
@@ -1,0 +1,10 @@
+{
+    "request": {
+        "method": "GET",
+        "url": "/links/universal-links"
+    },
+    "response": {
+        "status": 200,
+        "bodyFileName": "links/universal-links.html"
+    }
+}

--- a/wallet.xcodeproj/project.pbxproj
+++ b/wallet.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		831EDC101ED3A20E004F135B /* RenderedCertificateView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 831EDC0E1ED3A20E004F135B /* RenderedCertificateView.xib */; };
 		831EDC131ED5F7DA004F135B /* CoreBitcoinManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831EDC111ED5F7DA004F135B /* CoreBitcoinManager.swift */; };
 		831EDC141ED5F7DA004F135B /* Keychain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831EDC121ED5F7DA004F135B /* Keychain.swift */; };
+		83229D461F7EBF7100A3E012 /* DeepLinkOnFreshInstall.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83229D451F7EBF7100A3E012 /* DeepLinkOnFreshInstall.swift */; };
 		8329A0521DDA825200863285 /* IssuerSummaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8329A0501DDA825200863285 /* IssuerSummaryTableViewCell.swift */; };
 		8329A0531DDA825200863285 /* IssuerSummaryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8329A0511DDA825200863285 /* IssuerSummaryTableViewCell.xib */; };
 		832AE0151DF893A900A3CA4A /* SkyFloatingLabelTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 832AE0121DF893A900A3CA4A /* SkyFloatingLabelTextField.swift */; };
@@ -163,6 +164,7 @@
 		831EDC0E1ED3A20E004F135B /* RenderedCertificateView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = RenderedCertificateView.xib; sourceTree = "<group>"; };
 		831EDC111ED5F7DA004F135B /* CoreBitcoinManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreBitcoinManager.swift; sourceTree = "<group>"; };
 		831EDC121ED5F7DA004F135B /* Keychain.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Keychain.swift; sourceTree = "<group>"; };
+		83229D451F7EBF7100A3E012 /* DeepLinkOnFreshInstall.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepLinkOnFreshInstall.swift; sourceTree = "<group>"; };
 		8329A0501DDA825200863285 /* IssuerSummaryTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssuerSummaryTableViewCell.swift; sourceTree = "<group>"; };
 		8329A0511DDA825200863285 /* IssuerSummaryTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IssuerSummaryTableViewCell.xib; sourceTree = "<group>"; };
 		832AE0121DF893A900A3CA4A /* SkyFloatingLabelTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SkyFloatingLabelTextField.swift; path = External/SkyFloatingLabelTextField/Sources/SkyFloatingLabelTextField.swift; sourceTree = "<group>"; };
@@ -177,11 +179,6 @@
 		8337CFCE1E1D6B7A0080E876 /* RevealPassphraseTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RevealPassphraseTableViewController.swift; sourceTree = "<group>"; };
 		8337CFD11E1D78110080E876 /* LabeledTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LabeledTableViewCell.swift; sourceTree = "<group>"; };
 		833E674A1F47925E00773563 /* MainnetCertificateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainnetCertificateTests.swift; sourceTree = "<group>"; };
-		834A6EC11F54C75E00393A3A /* accepting_issuer_identity.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = accepting_issuer_identity.json; sourceTree = "<group>"; };
-		834A6EC31F54C75E00393A3A /* accepting_issuer_identity.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = accepting_issuer_identity.json; sourceTree = "<group>"; };
-		834A6EC41F54C75E00393A3A /* accepting_issuer_introduction.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = accepting_issuer_introduction.json; sourceTree = "<group>"; };
-		834A6EC51F54C75E00393A3A /* run.sh */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = run.sh; sourceTree = "<group>"; };
-		834A6EC61F54C75E00393A3A /* wiremock-standalone-2.7.1.jar */ = {isa = PBXFileReference; lastKnownFileType = archive.jar; path = "wiremock-standalone-2.7.1.jar"; sourceTree = "<group>"; };
 		834B94C51DC1618900543E4F /* IssuerCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IssuerCollectionViewCell.swift; sourceTree = "<group>"; };
 		834B94C61DC1618900543E4F /* IssuerCollectionViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = IssuerCollectionViewCell.xib; sourceTree = "<group>"; };
 		835226581F588F04006CB559 /* mainnet-2017-08-29.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "mainnet-2017-08-29.json"; sourceTree = "<group>"; };
@@ -396,35 +393,6 @@
 			path = Certificates;
 			sourceTree = "<group>";
 		};
-		834A6EBF1F54C75E00393A3A /* wiremock */ = {
-			isa = PBXGroup;
-			children = (
-				834A6EC01F54C75E00393A3A /* __files */,
-				834A6EC21F54C75E00393A3A /* mappings */,
-				834A6EC51F54C75E00393A3A /* run.sh */,
-				834A6EC61F54C75E00393A3A /* wiremock-standalone-2.7.1.jar */,
-			);
-			name = wiremock;
-			path = certificatesUITests/wiremock;
-			sourceTree = SOURCE_ROOT;
-		};
-		834A6EC01F54C75E00393A3A /* __files */ = {
-			isa = PBXGroup;
-			children = (
-				834A6EC11F54C75E00393A3A /* accepting_issuer_identity.json */,
-			);
-			path = __files;
-			sourceTree = "<group>";
-		};
-		834A6EC21F54C75E00393A3A /* mappings */ = {
-			isa = PBXGroup;
-			children = (
-				834A6EC31F54C75E00393A3A /* accepting_issuer_identity.json */,
-				834A6EC41F54C75E00393A3A /* accepting_issuer_introduction.json */,
-			);
-			path = mappings;
-			sourceTree = "<group>";
-		};
 		836031C11E5E5064005B2D2E /* Assets */ = {
 			isa = PBXGroup;
 			children = (
@@ -438,11 +406,11 @@
 			isa = PBXGroup;
 			children = (
 				8332F55E1F47549A002534D0 /* Resources */,
-				834A6EBF1F54C75E00393A3A /* wiremock */,
 				836075261F2A4D9800758C9E /* OnboardingUITests.swift */,
 				8332F5611F475512002534D0 /* ExistingIssuerTests.swift */,
 				833E674A1F47925E00773563 /* MainnetCertificateTests.swift */,
 				836B7E401F572C940086932D /* WebAuthIssuerTests.swift */,
+				83229D451F7EBF7100A3E012 /* DeepLinkOnFreshInstall.swift */,
 				836075201F2A4CD300758C9E /* Info.plist */,
 			);
 			path = certificatesUITests;
@@ -896,6 +864,7 @@
 				836075271F2A4D9800758C9E /* OnboardingUITests.swift in Sources */,
 				8332F5621F475512002534D0 /* ExistingIssuerTests.swift in Sources */,
 				833E674B1F47925E00773563 /* MainnetCertificateTests.swift in Sources */,
+				83229D461F7EBF7100A3E012 /* DeepLinkOnFreshInstall.swift in Sources */,
 				836B7E411F572C940086932D /* WebAuthIssuerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/wallet/AppDelegate.swift
+++ b/wallet/AppDelegate.swift
@@ -53,7 +53,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     // The app is launching with a document
     func application(_ app: UIApplication, open url: URL, options: [UIApplicationOpenURLOptionsKey : Any] = [:]) -> Bool {
         setupApplication()
-        return launchAddCertificate(at: url, showCertificate: true, animated: false)
+        launchAddCertificate(at: url, showCertificate: true, animated: false)
+        return true
     }
         
     func setupApplication() {
@@ -130,7 +131,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
                 print()
                 print(decodedCertificateString)
                 print()
-                return launchAddCertificate(at: certificateURL, showCertificate: true, animated: false)
+                launchAddCertificate(at: certificateURL, showCertificate: true, animated: false)
+                return true
             } else {
                 return false
             }
@@ -162,9 +164,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         issuerCollection?.autocompleteRequest = .addIssuer(identificationURL: introductionURL, nonce: nonce)
     }
     
-    func launchAddCertificate(at url: URL, showCertificate: Bool = false, animated: Bool = true) -> Bool {
-        let issuerCollection = popToIssuerCollection()
-        return issuerCollection?.add(certificateURL: url, silently: !showCertificate, animated: animated) ?? false
+    func launchAddCertificate(at url: URL, showCertificate: Bool = false, animated: Bool = true) {
+        let rootController = window?.rootViewController as? UINavigationController
+        let issuerCollection = rootController?.viewControllers.first as? IssuerCollectionViewController
+
+        issuerCollection?.autocompleteRequest = .addCertificate(certificateURL: url, silently: !showCertificate, animated: animated)
     }
     
     func popToIssuerCollection() -> IssuerCollectionViewController? {

--- a/wallet/AppDelegate.swift
+++ b/wallet/AppDelegate.swift
@@ -156,9 +156,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     func launchAddIssuer(at introductionURL: URL, with nonce: String) {
-        let issuerCollection = popToIssuerCollection()
+        let rootController = window?.rootViewController as? UINavigationController
+        let issuerCollection = rootController?.viewControllers.first as? IssuerCollectionViewController
         
-        issuerCollection?.showAddIssuerFlow(identificationURL: introductionURL, nonce: nonce)
+        issuerCollection?.autocompleteRequest = .addIssuer(identificationURL: introductionURL, nonce: nonce)
     }
     
     func launchAddCertificate(at url: URL, showCertificate: Bool = false, animated: Bool = true) -> Bool {

--- a/wallet/IssuerCollectionViewController.swift
+++ b/wallet/IssuerCollectionViewController.swift
@@ -257,11 +257,8 @@ class IssuerCollectionViewController: UICollectionViewController {
             break
         case .addIssuer(let identificationURL, let nonce):
             showAddIssuerFlow(identificationURL: identificationURL, nonce: nonce)
-        default:
-            print("UH OH. THis isn't handled yet.")
-            break
-//        case .addCertificate(let certificateURL):
-//            _ = add(certificateURL: certificateURL, silently: false, animated: true)
+        case .addCertificate(let certificateURL, let silently, let animated):
+            _ = add(certificateURL: certificateURL, silently: silently, animated: animated)
         }
     }
 

--- a/wallet/OnboardingViewControllers.swift
+++ b/wallet/OnboardingViewControllers.swift
@@ -49,7 +49,9 @@ class RestoreAccountViewController: UIViewController {
         }
         do {
             try Keychain.updateShared(with: passphrase)
-            dismiss(animated: true, completion: nil)
+            dismiss(animated: true, completion: {
+                NotificationCenter.default.post(name: NotificationNames.onboardingComplete, object: nil)
+            })
         } catch {
             failedPassphrase(error: NSLocalizedString("This isn't a valid passphrase. Check what you entered and try again.", comment: "Invalid replacement passphrase error"))
         }
@@ -104,6 +106,9 @@ class GeneratedPassphraseViewController: UIViewController {
     
     @IBAction func doneTapped() {
         dismiss(animated: true, completion: nil)
+        dismiss(animated: true) {
+            NotificationCenter.default.post(name: NotificationNames.onboardingComplete, object: nil)
+        }
     }
     
     func generatePassphrase() {

--- a/wallet/OnboardingViewControllers.swift
+++ b/wallet/OnboardingViewControllers.swift
@@ -105,7 +105,6 @@ class GeneratedPassphraseViewController: UIViewController {
     }
     
     @IBAction func doneTapped() {
-        dismiss(animated: true, completion: nil)
         dismiss(animated: true) {
             NotificationCenter.default.post(name: NotificationNames.onboardingComplete, object: nil)
         }

--- a/wallet/Utils/Constants.swift
+++ b/wallet/Utils/Constants.swift
@@ -49,6 +49,7 @@ enum Identifiers {
 }
 
 enum NotificationNames {
-    static let redirectToCertificate =  Notification.Name("RedirectToCertificate")
+    static let redirectToCertificate = Notification.Name("RedirectToCertificate")
+    static let onboardingComplete = Notification.Name("OnboardingComplete")
 }
 


### PR DESCRIPTION
This fixes #42. 

* When a deep link launches the app, we set an `AutocompleteRequest` value on the `IssuerCollectionViewController`.
* If we have a passphrase, it immediately handles it. If not, then it lets onboaring complete first.
* After onboarding a `OnboardingCompleted` notification is posted. `IssuerCollectionViewController` watches for this, then handles the stored `AutocompleteRequest`
* And it comes with tests! ✅ 