### PR TITLE
Updates to swift 4

### DIFF
--- a/certificatesUITests/Info.plist
+++ b/certificatesUITests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>106</string>
 </dict>

--- a/wallet.xcodeproj/project.pbxproj
+++ b/wallet.xcodeproj/project.pbxproj
@@ -1048,7 +1048,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "wallet/wallet-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -1068,7 +1068,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.blockcerts.cert-wallet";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "wallet/wallet-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -1086,7 +1086,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "wallet/walletTests-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/certificates.app/certificates";
 			};
 			name = Debug;
@@ -1104,7 +1104,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.learningmachine.walletTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "wallet/walletTests-Bridging-Header.h";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/certificates.app/certificates";
 			};
 			name = Release;
@@ -1121,7 +1121,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.learningmachine.certificatesUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = certificates;
 			};
 			name = Debug;
@@ -1138,7 +1138,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.learningmachine.certificatesUITests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.0;
 				TEST_TARGET_NAME = certificates;
 			};
 			name = Release;

--- a/wallet/AddIssuerViewController.swift
+++ b/wallet/AddIssuerViewController.swift
@@ -122,7 +122,7 @@ class AddIssuerViewController: UIViewController {
         }
     }
 
-    func saveIssuerTapped(_ sender: UIBarButtonItem) {
+    @objc func saveIssuerTapped(_ sender: UIBarButtonItem) {
         // TODO: validation.
         
         saveDataIntoFields()
@@ -135,7 +135,7 @@ class AddIssuerViewController: UIViewController {
         identifyAndIntroduceIssuer(at: identificationURL!)
     }
 
-    func cancelTapped(_ sender: UIBarButtonItem) {
+    @objc func cancelTapped(_ sender: UIBarButtonItem) {
         dismiss(animated: true, completion: nil)
     }
     
@@ -149,7 +149,7 @@ class AddIssuerViewController: UIViewController {
         }
     }
     
-    func keyboardDidShow(notification: NSNotification) {
+    @objc func keyboardDidShow(notification: NSNotification) {
         guard let info = notification.userInfo,
             let keyboardRect = info[UIKeyboardFrameBeginUserInfoKey] as? CGRect else {
             return
@@ -160,7 +160,7 @@ class AddIssuerViewController: UIViewController {
         scrollView.scrollIndicatorInsets = scrollInsets
     }
     
-    func keyboardDidHide(notification: NSNotification) {
+    @objc func keyboardDidHide(notification: NSNotification) {
         scrollView.contentInset = .zero
         scrollView.scrollIndicatorInsets = .zero
     }

--- a/wallet/AppDelegate.swift
+++ b/wallet/AppDelegate.swift
@@ -73,7 +73,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         resetSampleCertificateIfNeeded()
     }
     
-    func settingsDidChange() {
+    @objc func settingsDidChange() {
         resetSampleCertificateIfNeeded()
         enforceStrongOwnershipIfNeeded()
     }

--- a/wallet/CertificateMetadataViewController.swift
+++ b/wallet/CertificateMetadataViewController.swift
@@ -173,7 +173,7 @@ class CertificateMetadataViewController: UIViewController {
         }
     }
 
-    func dismissSelf() {
+    @objc func dismissSelf() {
         dismiss(animated: true, completion: nil)
     }
     

--- a/wallet/CertificateViewController.swift
+++ b/wallet/CertificateViewController.swift
@@ -153,7 +153,7 @@ class CertificateViewController: UIViewController {
         present(prompt, animated: true, completion: nil)
     }
     
-    func moreInfoTapped() {
+    @objc func moreInfoTapped() {
         let controller = CertificateMetadataViewController(certificate: certificate)
         controller.delegate = self
         let navController = UINavigationController(rootViewController: controller);

--- a/wallet/Info.plist
+++ b/wallet/Info.plist
@@ -30,7 +30,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>106</string>
 	<key>ITSAppUsesNonExemptEncryption</key>

--- a/wallet/IssuerCollectionViewController.swift
+++ b/wallet/IssuerCollectionViewController.swift
@@ -59,7 +59,7 @@ class IssuerCollectionViewController: UICollectionViewController {
         self.navigationController?.navigationBar.barTintColor = .brandColor
         self.navigationController?.navigationBar.tintColor = .tintColor
         navigationController?.navigationBar.titleTextAttributes = [
-            NSForegroundColorAttributeName: UIColor.titleColor
+            NSAttributedStringKey.foregroundColor: UIColor.titleColor
         ]
 
         // Load any existing issuers.
@@ -178,7 +178,7 @@ class IssuerCollectionViewController: UICollectionViewController {
         present(controller, animated: true, completion: nil)
     }
 
-    func addIssuerButtonTapped() {
+    @objc func addIssuerButtonTapped() {
         showAddIssuerFlow()
     }
 
@@ -233,7 +233,7 @@ class IssuerCollectionViewController: UICollectionViewController {
     }
     
     // Mark: Notifications
-    func redirectRequested(notification: Notification) {
+    @objc func redirectRequested(notification: Notification) {
         guard let info = notification.userInfo as? [String: Certificate] else {
             print("Redirect requested without a certificate. Ignoring.")
             return
@@ -246,7 +246,7 @@ class IssuerCollectionViewController: UICollectionViewController {
         shouldRedirectToCertificate = certificate
     }
     
-    func onboardingCompleted(notification: Notification) {
+    @objc func onboardingCompleted(notification: Notification) {
         precondition(Keychain.hasPassphrase(), "OnboardingCompleted notification shouldn't fire until they keychain has a passphrase.")
         processAutocompleteRequest()
     }

--- a/wallet/IssuerTableViewController.swift
+++ b/wallet/IssuerTableViewController.swift
@@ -99,7 +99,7 @@ class IssuerTableViewController: UITableViewController {
         let label = UILabel()
         label.text = NSLocalizedString("Certificates", comment: "Section title listing all certificates from this issuer.").uppercased()
         label.textColor = .primaryTextColor
-        label.font = UIFont.systemFont(ofSize: 11, weight: UIFontWeightBold)
+        label.font = UIFont.systemFont(ofSize: 11, weight: UIFont.Weight.bold)
         label.translatesAutoresizingMaskIntoConstraints = false
         
         let separator = UIView()
@@ -142,7 +142,7 @@ class IssuerTableViewController: UITableViewController {
     }
     
     // MARK: Key actions
-    func confirmDeleteIssuer() {
+    @objc func confirmDeleteIssuer() {
         guard let issuerToDelete = self.managedIssuer else {
             return
         }

--- a/wallet/IssuerViewController.swift
+++ b/wallet/IssuerViewController.swift
@@ -57,7 +57,7 @@ class IssuerViewController: UIViewController {
         }
     }
     
-    func addCertificateTapped() {
+    @objc func addCertificateTapped() {
         let addCertificateFromFile = NSLocalizedString("Import Certificate from File", comment: "Contextual action. Tapping this prompts the user to add a file from a document provider.")
         let addCertificateFromURL = NSLocalizedString("Import Certificate from URL", comment: "Contextual action. Tapping this prompts the user for a URL to pull the certificate from.")
         let cancelAction = NSLocalizedString("Cancel", comment: "Cancel action")

--- a/wallet/LabeledTableViewCell.swift
+++ b/wallet/LabeledTableViewCell.swift
@@ -16,12 +16,12 @@ class LabeledTableViewCell: UITableViewCell {
         titleLabel = UILabel()
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.numberOfLines = 1
-        titleLabel.font = UIFont.systemFont(ofSize: 12, weight: UIFontWeightThin)
+        titleLabel.font = UIFont.systemFont(ofSize: 12, weight: UIFont.Weight.thin)
         
         contentLabel = UILabel()
         contentLabel.translatesAutoresizingMaskIntoConstraints = false
         contentLabel.numberOfLines = 0
-        contentLabel.font = UIFont.systemFont(ofSize: 14, weight: UIFontWeightRegular)
+        contentLabel.font = UIFont.systemFont(ofSize: 14, weight: UIFont.Weight.regular)
         
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         selectionStyle = .none

--- a/wallet/OnboardingViewControllers.swift
+++ b/wallet/OnboardingViewControllers.swift
@@ -151,7 +151,7 @@ class RectangularButton : UIButton {
         layer.borderWidth = 0.5
         contentEdgeInsets = UIEdgeInsets(top: edgeInsets, left: edgeInsets, bottom: edgeInsets, right: edgeInsets)
         tintColor = .black
-        titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: UIFontWeightMedium)
+        titleLabel?.font = UIFont.systemFont(ofSize: 14, weight: UIFont.Weight.medium)
         
         setTitleColor(.black, for: .normal)
         setTitleColor(.black, for: .selected)
@@ -181,7 +181,7 @@ class TitleLabel: UILabel {
     }
     
     func commonInit() {
-        self.font = UIFont.systemFont(ofSize: 20, weight: UIFontWeightMedium)
+        self.font = UIFont.systemFont(ofSize: 20, weight: UIFont.Weight.medium)
     }
 }
 

--- a/wallet/ReplacePassphraseViewController.swift
+++ b/wallet/ReplacePassphraseViewController.swift
@@ -38,7 +38,7 @@ class ReplacePassphraseViewController: UIViewController {
         navigationItem.rightBarButtonItem = replaceButton
     }
     
-    func saveNewPassphrase() {
+    @objc func saveNewPassphrase() {
         resignFirstResponder()
         errorLabel.text = nil
         

--- a/wallet/SettingsTableViewController.swift
+++ b/wallet/SettingsTableViewController.swift
@@ -64,7 +64,7 @@ class SettingsTableViewController: UITableViewController {
         navigationController?.navigationBar.barStyle = barStyle
     }
 
-    func dismissSettings() {
+    @objc func dismissSettings() {
         dismiss(animated: true, completion: nil)
     }
 

--- a/wallet/Utils/Extensions.swift
+++ b/wallet/Utils/Extensions.swift
@@ -21,7 +21,7 @@ extension UILabel {
         let size: CGSize = (string as NSString).boundingRect(
             with: CGSize(width: self.frame.size.width, height: CGFloat.greatestFiniteMagnitude),
             options: NSStringDrawingOptions.usesLineFragmentOrigin,
-            attributes: [NSFontAttributeName: self.font],
+            attributes: [NSAttributedStringKey.font: self.font],
             context: nil).size
         
         return (size.height > self.bounds.size.height)

--- a/wallet/WebLoginViewController.swift
+++ b/wallet/WebLoginViewController.swift
@@ -48,7 +48,7 @@ class WebLoginViewController: UIViewController {
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.cancelWebLogin))
     }
     
-    func cancelWebLogin() {
+    @objc func cancelWebLogin() {
         cancelCallback()
     }
 }

--- a/walletTests/Info.plist
+++ b/walletTests/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.1.1</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>106</string>
 </dict>


### PR DESCRIPTION
* SkyFloatingLabelTextField was updated to swift 4, so now we can too!
* This includes a number of changes to address deprecations in Swift 3. This includes adding `@objc` to any functions that need to be called by the objective-c runtime (mostly selectors) and using the new UIFont structs to specify font weight.